### PR TITLE
[cards registrar] Process all requests from file even if some of them have failed

### DIFF
--- a/tools/virgil-iot-registrar/registrar/registrar.go
+++ b/tools/virgil-iot-registrar/registrar/registrar.go
@@ -291,14 +291,6 @@ func (r *cardsRegistrar) registerCard(decryptedRequest string) error {
 }
 
 func (r *cardsRegistrar) saveFailedRequests() error {
-	// Remove previous file if exists
-	var _, stat = os.Stat(r.failedRequestsFile)
-	if os.IsExist(stat) {
-		if err := os.Remove(r.failedRequestsFile); err != nil {
-			return fmt.Errorf("failed to remove previous file with failed requests: %v", err)
-		}
-	}
-
 	// Create file
 	var file, err = os.Create(r.failedRequestsFile)
 	if err != nil {


### PR DESCRIPTION
If error has occurred during cards processing:
1) log it to stderr
2) save it to slice with errors
3) at the end of processing return error which consists of all fails