### PR TITLE
Feature/1854,1855 cpp compatible,mcu build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -92,7 +92,7 @@ endif()
 #
 #   Target platform
 #
-option(VIRGIL_IOT_MCU_BUILD "Enable build for MCU" ON)
+option(VIRGIL_IOT_MCU_BUILD "Disable build for MCU by default" OFF)
 
 #
 #   Additional HAL include paths

--- a/default-impl/cloud/virgil-message-bin/aws-message-bin/include/virgil/iot/vs-aws-message-bin/aws-message-bin.h
+++ b/default-impl/cloud/virgil-message-bin/aws-message-bin/include/virgil/iot/vs-aws-message-bin/aws-message-bin.h
@@ -54,7 +54,9 @@ vs_cloud_init(vs_curl_http_impl(), vs_aws_message_bin_impl(), secmodule_impl);
 \endcode
 *
 * You need to implement custom storage. As an example you can see default implementation in
-* <a href="https://github.com/VirgilSecurity/demo-iotkit-nix/blob/release/v0.1.0-alpha/common/src/helpers/app-storage.c#L73">vs_app_storage_init_impl()</a> function in app-storage.c file.
+* <a
+href="https://github.com/VirgilSecurity/demo-iotkit-nix/blob/release/v0.1.0-alpha/common/src/helpers/app-storage.c#L73">vs_app_storage_init_impl()</a>
+function in app-storage.c file.
 */
 
 #ifndef VS_AWS_DEFAULT_MESSAGE_BIN_IMPL_H

--- a/default-impl/cloud/virgil-thing-service/curl-thing-service/include/virgil/iot/vs-curl-http/curl-http.h
+++ b/default-impl/cloud/virgil-thing-service/curl-thing-service/include/virgil/iot/vs-curl-http/curl-http.h
@@ -54,7 +54,9 @@ vs_cloud_init(vs_curl_http_impl(), vs_aws_message_bin_impl(), secmodule_impl);
 \endcode
 *
 * You need to implement custom storage implementation. As an example you can see default implementation in
-* <a href="https://github.com/VirgilSecurity/demo-iotkit-nix/blob/release/v0.1.0-alpha/common/src/helpers/app-storage.c#L73"> vs_app_storage_init_impl()</a> function in app-storage.c file.
+* <a
+href="https://github.com/VirgilSecurity/demo-iotkit-nix/blob/release/v0.1.0-alpha/common/src/helpers/app-storage.c#L73">
+vs_app_storage_init_impl()</a> function in app-storage.c file.
  */
 
 #ifndef VS_CURL_HTTP_DEFAULT_IMPL_H

--- a/helpers/json/include/virgil/iot/json/json_generator.h
+++ b/helpers/json/include/virgil/iot/json/json_generator.h
@@ -75,6 +75,11 @@
 #ifndef _JSON_GENERATOR_H_
 #define _JSON_GENERATOR_H_
 
+#ifdef __cplusplus
+namespace VirgilIoTKit {
+extern "C" {
+#endif
+
 #define MAX_JSON_STR_LEN 64  /* Maximum object or member name length */
 #define MAX_JSON_VAL_LEN 128 /* Maximum value name length */
 typedef enum {
@@ -398,4 +403,10 @@ json_set_array_value(struct json_str *jptr, char *str, int value, float val, jso
 #define json_set_array_bool(jptr, val)                                                                                 \
     ((val == true) ? (json_set_array_value(jptr, NULL, 1, 0.0, JSON_VAL_BOOL))                                         \
                    : (json_set_array_value(jptr, NULL, 0, 0.0, JSON_VAL_BOOL)))
+
+#ifdef __cplusplus
+} // extern "C"
+} // namespace VirgilIoTKit
+#endif
+
 #endif /* _JSON_GENERATOR_H_ */

--- a/helpers/json/include/virgil/iot/json/json_parser.h
+++ b/helpers/json/include/virgil/iot/json/json_parser.h
@@ -127,6 +127,11 @@
 #include <stdint.h>
 #include "jsmn.h"
 
+#ifdef __cplusplus
+namespace VirgilIoTKit {
+extern "C" {
+#endif
+
 #define MOD_ERROR_START(x) (x << 12 | 0)
 
 #ifdef JSMN_SHORT_TOKENS
@@ -723,5 +728,10 @@ json_array_get_array_object(jobj_t *jobj, uint16_t index, int *num_elements);
  */
 int
 json_array_release_array_object(jobj_t *jobj);
+
+#ifdef __cplusplus
+} // extern "C"
+} // namespace VirgilIoTKit
+#endif
 
 #endif /* __JSON_PARSER_H__ */

--- a/helpers/status_code/include/virgil/iot/status_code/status_code.h
+++ b/helpers/status_code/include/virgil/iot/status_code/status_code.h
@@ -65,6 +65,11 @@
 
 #include <virgil/iot/macros/macros.h>
 
+#ifdef __cplusplus
+namespace VirgilIoTKit {
+extern "C" {
+#endif
+
 /** Status code
  *
  * Zero value #VS_CODE_OK is used for non-error values. Negative values mean error
@@ -158,5 +163,10 @@ typedef enum {
  *  \return false in case of non-successful result.
  */
 #define STATUS_CHECK_RET_BOOL(OPERATION, MESSAGE, ...)   BOOL_CHECK_RET(VS_CODE_OK == (OPERATION), (MESSAGE), ##__VA_ARGS__)
+
+#ifdef __cplusplus
+} // extern "C"
+} // namespace VirgilIoTKit
+#endif
 
 #endif // VS_IOT_SDK_STATUS_CODE

--- a/helpers/storage_hal/include/virgil/iot/storage_hal/storage_hal.h
+++ b/helpers/storage_hal/include/virgil/iot/storage_hal/storage_hal.h
@@ -62,6 +62,11 @@
 #include <virgil/iot/status_code/status_code.h>
 #include <sys/types.h>
 
+#ifdef __cplusplus
+namespace VirgilIoTKit {
+extern "C" {
+#endif
+
 #define VS_STORAGE_ELEMENT_ID_MAX  (32)
 
 typedef uint8_t vs_storage_element_id_t[VS_STORAGE_ELEMENT_ID_MAX];
@@ -219,5 +224,10 @@ typedef struct {
     size_t file_sz_limit; /**< Maximum size of storage element */
 
 } vs_storage_op_ctx_t;
+
+#ifdef __cplusplus
+} // extern "C"
+} // namespace VirgilIoTKit
+#endif
 
 #endif //VS_STORAGE_HAL_H

--- a/helpers/update/include/virgil/iot/update/update.h
+++ b/helpers/update/include/virgil/iot/update/update.h
@@ -54,6 +54,11 @@
 #include <virgil/iot/status_code/status_code.h>
 #include <virgil/iot/provision/provision.h>
 
+#ifdef __cplusplus
+namespace VirgilIoTKit {
+extern "C" {
+#endif
+
 /** File types */
 enum vs_update_file_type_id_t {
     VS_UPDATE_FIRMWARE, /**< Firmware files for different manufactures and device types */
@@ -290,5 +295,10 @@ typedef struct __attribute__((__packed__)) vs_update_interface_t {
     vs_storage_op_ctx_t *storage_context; /**< Storage context */
 
 } vs_update_interface_t;
+
+#ifdef __cplusplus
+} // extern "C"
+} // namespace VirgilIoTKit
+#endif
 
 #endif // VS_UPDATE_H

--- a/modules/cloud/include/virgil/iot/cloud/base64.h
+++ b/modules/cloud/include/virgil/iot/cloud/base64.h
@@ -115,6 +115,7 @@
 #include <stdbool.h>
 
 #ifdef __cplusplus
+namespace VirgilIoTKit {
 extern "C" {
 #endif
 
@@ -182,7 +183,8 @@ bool
 base64encode(const unsigned char *in, int inlen, char *out, int *outlen);
 
 #ifdef __cplusplus
-}
+} // extern "C"
+} // namespace VirgilIoTKit
 #endif
 
 #endif /* _BASE64_H_ */

--- a/modules/cloud/include/virgil/iot/cloud/cloud.h
+++ b/modules/cloud/include/virgil/iot/cloud/cloud.h
@@ -46,8 +46,8 @@
  * \section cloud_usage Cloud Usage
  *
  * Function #vs_cloud_message_bin_process tries to obtain credentials for connecting to message bin broker from thing
- * service using #vs_cloud_http_request_func_t and connect to the broker using #vs_cloud_mb_connect_subscribe_func_t. Then
- * it waits for new messages, periodically calling #vs_cloud_mb_process_func_t. User can register own handlers for
+ * service using #vs_cloud_http_request_func_t and connect to the broker using #vs_cloud_mb_connect_subscribe_func_t.
+ * Then it waits for new messages, periodically calling #vs_cloud_mb_process_func_t. User can register own handlers for
  * events of new firmware or trust list by calling #vs_cloud_message_bin_register_default_handler or custom handler for
  * raw data processing from some topics by calling #vs_cloud_message_bin_register_custom_handler. Cloud module uses
  * provision and firmware modules, which must be initialized before.
@@ -153,6 +153,11 @@ tl_topic_process(const uint8_t *url, uint16_t length) {
 #include <virgil/iot/firmware/firmware.h>
 #include <global-hal.h>
 #include <virgil/iot/status_code/status_code.h>
+
+#ifdef __cplusplus
+namespace VirgilIoTKit {
+extern "C" {
+#endif
 
 /** Length of the update URL string */
 #define VS_UPD_URL_STR_SIZE 200
@@ -377,5 +382,10 @@ vs_status_e
 vs_cloud_init(const vs_cloud_impl_t *cloud_impl,
               const vs_cloud_message_bin_impl_t *message_bin_impl,
               vs_secmodule_impl_t *secmodule);
+
+#ifdef __cplusplus
+} // extern "C"
+} // namespace VirgilIoTKit
+#endif
 
 #endif // VS_CLOUD_H

--- a/modules/crypto/converters/include/virgil/iot/converters/crypto_format_converters.h
+++ b/modules/crypto/converters/include/virgil/iot/converters/crypto_format_converters.h
@@ -61,6 +61,7 @@
 #include <virgil/iot/secmodule/secmodule.h>
 
 #ifdef __cplusplus
+namespace VirgilIoTKit {
 extern "C" {
 #endif
 
@@ -180,9 +181,9 @@ vs_converters_raw_sign_to_mbedtls(vs_secmodule_keypair_type_e keypair_type,
                                   uint16_t buf_sz,
                                   uint16_t *signature_sz);
 
-
 #ifdef __cplusplus
-}
+} // extern "C"
+} // namespace VirgilIoTKit
 #endif
 
 #endif // VS_CRYPTO_CONVERTERS_H

--- a/modules/crypto/secmodule/include/virgil/iot/secmodule/devices/secmodule-soft.h
+++ b/modules/crypto/secmodule/include/virgil/iot/secmodule/devices/secmodule-soft.h
@@ -44,6 +44,11 @@
 #ifndef VS_SECMODULE_SOFT_DEVICE_H
 #define VS_SECMODULE_SOFT_DEVICE_H
 
+#ifdef __cplusplus
+namespace VirgilIoTKit {
+extern "C" {
+#endif
+
 /** Maximum data size of standard slot */
 #define KEY_SLOT_STD_DATA_SIZE (380)
 
@@ -128,5 +133,10 @@ typedef enum {
 #define FW1_KEY_SLOT VS_KEY_SLOT_STD_MTP_6
 /** Firmware key 2 slot */
 #define FW2_KEY_SLOT VS_KEY_SLOT_STD_MTP_7
+
+#ifdef __cplusplus
+} // extern "C"
+} // namespace VirgilIoTKit
+#endif
 
 #endif // VS_SECMODULE_SOFT_DEVICE_H

--- a/modules/crypto/secmodule/include/virgil/iot/secmodule/secmodule-helpers.h
+++ b/modules/crypto/secmodule/include/virgil/iot/secmodule/secmodule-helpers.h
@@ -42,6 +42,11 @@
 #ifndef VS_SECMODULE_HELPERS_H_
 #define VS_SECMODULE_HELPERS_H_
 
+#ifdef __cplusplus
+namespace VirgilIoTKit {
+extern "C" {
+#endif
+
 #include <virgil/iot/secmodule/secmodule.h>
 
 #define VS_PUBKEY_SECP192_LEN (49)
@@ -155,4 +160,10 @@ vs_secmodule_tiny_secp256_signature_to_virgil(const uint8_t raw_signature[VS_SIG
                                               uint8_t *virgil_sign,
                                               uint16_t buf_sz,
                                               uint16_t *virgil_sign_sz);
+
+#ifdef __cplusplus
+} // extern "C"
+} // namespace VirgilIoTKit
+#endif
+
 #endif // VS_SECMODULE_HELPERS_H_

--- a/modules/crypto/secmodule/include/virgil/iot/secmodule/secmodule.h
+++ b/modules/crypto/secmodule/include/virgil/iot/secmodule/secmodule.h
@@ -67,6 +67,11 @@ vs_soft_secmodule_deinit();
 #include <virgil/iot/status_code/status_code.h>
 #include <virgil/iot/secmodule/devices/secmodule-soft.h>
 
+#ifdef __cplusplus
+namespace VirgilIoTKit {
+extern "C" {
+#endif
+
 /** Keypair types */
 typedef enum {
     VS_KEYPAIR_INVALID = -1, /**< Invalid keypair */
@@ -541,5 +546,10 @@ vs_secmodule_ecies_encrypt(const vs_secmodule_impl_t *secmodule_impl,
                            uint8_t *cryptogram,
                            size_t buf_sz,
                            size_t *cryptogram_sz);
+
+#ifdef __cplusplus
+} // extern "C"
+} // namespace VirgilIoTKit
+#endif
 
 #endif // VS_SECMODULE_INTERFACE_API_H

--- a/modules/firmware/include/virgil/iot/firmware/firmware.h
+++ b/modules/firmware/include/virgil/iot/firmware/firmware.h
@@ -215,6 +215,11 @@ Firmware module");
 #include <virgil/iot/update/update.h>
 #include <virgil/iot/secmodule/secmodule.h>
 
+#ifdef __cplusplus
+namespace VirgilIoTKit {
+extern "C" {
+#endif
+
 /** Firmware descriptor */
 typedef struct __attribute__((__packed__)) {
     vs_file_info_t info;      /**< File information */
@@ -511,5 +516,10 @@ vs_firmware_hton_descriptor(vs_firmware_descriptor_t *desc);
  */
 void
 vs_firmware_hton_header(vs_firmware_header_t *header);
+
+#ifdef __cplusplus
+} // extern "C"
+} // namespace VirgilIoTKit
+#endif
 
 #endif // VS_FIRMWARE_H

--- a/modules/firmware/include/virgil/iot/firmware/firmware_hal.h
+++ b/modules/firmware/include/virgil/iot/firmware/firmware_hal.h
@@ -45,6 +45,11 @@
 
 #include <virgil/iot/status_code/status_code.h>
 
+#ifdef __cplusplus
+namespace VirgilIoTKit {
+extern "C" {
+#endif
+
 /** Prepare space
  *
  * Signature for function that is called by #vs_firmware_install_firmware Firmware library function to prepare space for
@@ -88,5 +93,10 @@ vs_firmware_install_append_data_hal(const void *data, uint16_t data_sz);
  */
 vs_status_e
 vs_firmware_get_own_firmware_footer_hal(void *footer, size_t footer_sz);
+
+#ifdef __cplusplus
+} // extern "C"
+} // namespace VirgilIoTKit
+#endif
 
 #endif // VS_FIRMWARE_INTERFACE_H

--- a/modules/logger/include/virgil/iot/logger/logger.h
+++ b/modules/logger/include/virgil/iot/logger/logger.h
@@ -72,6 +72,11 @@ logger_hal_implementation
 #include <stdarg.h>
 #include <string.h>
 
+#ifdef __cplusplus
+namespace VirgilIoTKit {
+extern "C" {
+#endif
+
 /** Logging level
  */
 typedef enum {
@@ -292,5 +297,10 @@ vs_logger_message_hex(vs_log_level_t level,
 #define VS_LOG_DEBUG(FRMT, ...) VS_IOT_MAP(VS_IOT_LOGGER_VOID, FRMT, ##__VA_ARGS__)
 
 #endif // VS_IOT_LOGGER_USE_LIBRARY
+
+#ifdef __cplusplus
+} // extern "C"
+} // namespace VirgilIoTKit
+#endif
 
 #endif // AP_SECURITY_SDK_LOGGER_H

--- a/modules/protocols/snap/include/private/snap-private.h
+++ b/modules/protocols/snap/include/private/snap-private.h
@@ -37,7 +37,7 @@
 
 #include <virgil/iot/protocols/snap/snap-structs.h>
 
-int
+vs_status_e
 _snap_fill_header(const vs_mac_addr_t *recipient_mac, vs_snap_packet_t *packet);
 
 vs_snap_transaction_id_t

--- a/modules/protocols/snap/include/virgil/iot/protocols/snap.h
+++ b/modules/protocols/snap/include/virgil/iot/protocols/snap.h
@@ -49,12 +49,16 @@
  * #vs_snap_service_t structure and register service by #vs_snap_register_service call.
  */
 
+#ifndef AP_SECURITY_SDK_SNAP_H
+#define AP_SECURITY_SDK_SNAP_H
+
 #include <stdint.h>
 
 #include <virgil/iot/protocols/snap/snap-structs.h>
 #include <virgil/iot/status_code/status_code.h>
 
 #ifdef __cplusplus
+namespace VirgilIoTKit {
 extern "C" {
 #endif
 
@@ -144,7 +148,7 @@ vs_snap_send(const vs_netif_t *netif, const uint8_t *data, uint16_t data_sz);
  * \return #VS_CODE_OK in case of success or error code.
  */
 vs_status_e
-vs_snap_register_service(const vs_snap_service_t *service);
+vs_snap_register_service(vs_snap_service_t *service);
 
 /** MAC address
  *
@@ -194,5 +198,8 @@ vs_snap_stat_t
 vs_snap_get_statistics(void);
 
 #ifdef __cplusplus
-}
+} // extern "C"
+} // namespace VirgilIoTKit
 #endif
+
+#endif // AP_SECURITY_SDK_SNAP_H

--- a/modules/protocols/snap/include/virgil/iot/protocols/snap/fldt/fldt-client.h
+++ b/modules/protocols/snap/include/virgil/iot/protocols/snap/fldt/fldt-client.h
@@ -50,7 +50,7 @@
  *
  * Here you can see an example of FLDT client initialization :
  * \code
- *  const vs_snap_service_t *snap_fldt_client;
+ *  vs_snap_service_t *snap_fldt_client;
  *  snap_fldt_client = vs_snap_fldt_client( _on_file_updated );
  *  STATUS_CHECK( vs_snap_register_service( snap_fldt_client ), "Cannot register FLDT client service");
  *  STATUS_CHECK( vs_fldt_client_add_file_type( vs_firmware_update_file_type(), vs_firmware_update_ctx() ),
@@ -92,13 +92,14 @@
 
 #if FLDT_CLIENT
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 #include <virgil/iot/protocols/snap/snap-structs.h>
 #include <virgil/iot/status_code/status_code.h>
 #include <virgil/iot/update/update.h>
+
+#ifdef __cplusplus
+namespace VirgilIoTKit {
+extern "C" {
+#endif
 
 /** Got new file callback
  *
@@ -128,7 +129,7 @@ typedef void (*vs_fldt_got_file)(vs_update_file_type_t *file_type,
  *
  * \return #vs_snap_service_t SNAP service description. Use this pointer to call #vs_snap_register_service.
  */
-const vs_snap_service_t *
+vs_snap_service_t *
 vs_snap_fldt_client(vs_fldt_got_file got_file_callback);
 
 /** Add file type
@@ -155,7 +156,8 @@ vs_status_e
 vs_fldt_client_request_all_files(void);
 
 #ifdef __cplusplus
-}
+} // extern "C"
+} // namespace VirgilIoTKit
 #endif
 
 #endif // FLDT_CLIENT

--- a/modules/protocols/snap/include/virgil/iot/protocols/snap/fldt/fldt-server.h
+++ b/modules/protocols/snap/include/virgil/iot/protocols/snap/fldt/fldt-server.h
@@ -49,7 +49,7 @@
  *
  * Here you can see an example of FLDT server initialization :
  * \code
- *  const vs_snap_service_t *snap_fldt_server;
+ *  vs_snap_service_t *snap_fldt_server;
  *  const vs_mac_addr_t mac_addr;
  *  snap_fldt_server = vs_snap_fldt_server( &mac_addr, _add_filetype );
  *
@@ -89,13 +89,14 @@
 
 #if FLDT_SERVER
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 #include <virgil/iot/update/update.h>
 #include <virgil/iot/protocols/snap/snap-structs.h>
 #include <virgil/iot/status_code/status_code.h>
+
+#ifdef __cplusplus
+namespace VirgilIoTKit {
+extern "C" {
+#endif
 
 /** Add new file type callback
  *
@@ -123,7 +124,7 @@ typedef vs_status_e (*vs_fldt_server_add_filetype_cb)(const vs_update_file_type_
  *
  * \return #vs_snap_service_t SNAP service description. Use this pointer to call #vs_snap_register_service.
  */
-const vs_snap_service_t *
+vs_snap_service_t *
 vs_snap_fldt_server(const vs_mac_addr_t *gateway_mac, vs_fldt_server_add_filetype_cb add_filetype);
 
 /** Add file type
@@ -143,7 +144,8 @@ vs_fldt_server_add_file_type(const vs_update_file_type_t *file_type,
                              bool broadcast_file_info);
 
 #ifdef __cplusplus
-}
+} // extern "C"
+} // namespace VirgilIoTKit
 #endif
 
 #endif // FLDT_SERVER

--- a/modules/protocols/snap/include/virgil/iot/protocols/snap/info/info-client.h
+++ b/modules/protocols/snap/include/virgil/iot/protocols/snap/info/info-client.h
@@ -50,7 +50,7 @@
  *
  * \code
  *
- *     const vs_snap_service_t *snap_info_client;     // INFO service
+ *     vs_snap_service_t *snap_info_client;           // INFO service
  *     vs_snap_info_device_t devices[100];            // Devices list. Assuming 100 devices in the list is enough
  *     const size_t devices_max = sizeof(devices) / sizeof(devices[0]);   // Maximum devices in the list
  *     size_t devices_amount = 0;                     // Enumerates devices amount
@@ -83,26 +83,26 @@
  * \code
  *
  * vs_status_e
- * _device_start_impl(vs_snap_info_device_t *device) {
+ * _device_start_impl(struct vs_snap_service_t *service, vs_snap_info_device_t *device) {
  *      // Process startup notification
  *  }
  *
  * vs_status_e
- * _general_info_impl(vs_info_general_t *general_info) {
+ * _general_info_impl(struct vs_snap_service_t *service, vs_info_general_t *general_info) {
  *      // Process general device information
  *  }
  *
  * vs_status_e
- * _statistics_impl(vs_info_statistics_t *statistics) {
+ * _statistics_impl(struct vs_snap_service_t *service, vs_info_statistics_t *statistics) {
  *      // Process device statistics
  *  }
 
- * vs_snap_info_callbacks_t
+ * vs_snap_info_client_service_t
  * _info_client_impl() {
- *      vs_snap_info_callbacks_t impl;
- *      impl.device_start_cb = _device_start_impl;
- *      impl.general_info_cb = _general_info_impl;
- *      impl.statistics_cb = _statistics_impl;
+ *      vs_snap_info_client_service_t impl;
+ *      impl.device_start = _device_start_impl;
+ *      impl.general_info = _general_info_impl;
+ *      impl.statistics = _statistics_impl;
  * }
  *
  * \endcode
@@ -117,13 +117,14 @@
 
 #if INFO_CLIENT
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 #include <virgil/iot/protocols/snap/info/info-structs.h>
 #include <virgil/iot/protocols/snap/snap-structs.h>
 #include <virgil/iot/status_code/status_code.h>
+
+#ifdef __cplusplus
+namespace VirgilIoTKit {
+extern "C" {
+#endif
 
 /** Wait implementation
  *
@@ -148,11 +149,12 @@ typedef vs_status_e (*vs_snap_info_stop_wait_t)(int *condition, int expect);
  *
  * This function is called by receiving startup notification from device.
  *
- * \param[in] device #vs_snap_info_device_t device information.
+ * \param[in] service Snap Service context with user data. Cannot be NULL.
+ * \param[in] device Device statical information. Cannot be NULL.
  *
  * \return #VS_CODE_OK in case of success or error code.
  */
-typedef vs_status_e (*vs_snap_info_start_notif_cb_t)(vs_snap_info_device_t *device);
+typedef vs_status_e (*vs_snap_info_start_notif_cb_t)(struct vs_snap_service_t *service, vs_snap_info_device_t *device);
 
 /** General device information request
  *
@@ -161,11 +163,12 @@ typedef vs_status_e (*vs_snap_info_start_notif_cb_t)(vs_snap_info_device_t *devi
  * General device information polling is started by #vs_snap_info_set_polling call when \a elements contains
  * VS_SNAP_INFO_GENERAL bit.
  *
- * \param[in] general_info #vs_info_general_t device information.
+ * \param[in] service Snap Service context with user data. Cannot be NULL.
+ * \param[in] general_info Device general information. Cannot be NULL.
  *
  * \return #VS_CODE_OK in case of success or error code.
  */
-typedef vs_status_e (*vs_snap_info_general_cb_t)(vs_info_general_t *general_info);
+typedef vs_status_e (*vs_snap_info_general_cb_t)(struct vs_snap_service_t *service, vs_info_general_t *general_info);
 
 /** Device statistics request
  *
@@ -174,11 +177,13 @@ typedef vs_status_e (*vs_snap_info_general_cb_t)(vs_info_general_t *general_info
  * General device information polling is started by #vs_snap_info_set_polling call when \a elements contains
  * VS_SNAP_INFO_STATISTICS bit.
  *
- * \param[in] statistics #vs_info_statistics_t device information.
+ * \param[in] service Snap Service context with user data. Cannot be NULL.
+ * \param[in] statistics Device statistics. Cannot be NULL.
  *
  * \return #VS_CODE_OK in case of success or error code.
  */
-typedef vs_status_e (*vs_snap_info_statistics_cb_t)(vs_info_statistics_t *statistics);
+typedef vs_status_e (*vs_snap_info_statistics_cb_t)(struct vs_snap_service_t *service,
+                                                    vs_info_statistics_t *statistics);
 
 /** INFO client implementations
  *
@@ -186,21 +191,21 @@ typedef vs_status_e (*vs_snap_info_statistics_cb_t)(vs_info_statistics_t *statis
  *
  */
 typedef struct {
-    vs_snap_info_start_notif_cb_t device_start_cb; /**< Startup notification */
-    vs_snap_info_general_cb_t general_info_cb;     /**< General information */
-    vs_snap_info_statistics_cb_t statistics_cb;    /**< Device statistics */
-} vs_snap_info_callbacks_t;
+    vs_snap_info_start_notif_cb_t device_start; /**< Startup notification */
+    vs_snap_info_general_cb_t general_info;     /**< General information */
+    vs_snap_info_statistics_cb_t statistics;    /**< Device statistics */
+} vs_snap_info_client_service_t;
 
 /** INFO Client SNAP Service implementation
  *
  * This call returns INFO client implementation. It must be called before any INFO call.
  *
- * \param[in] callbacks #vs_snap_info_callbacks_t callbacks. Must not be NULL.
+ * \param[in] impl Snap Info Client functions implementation.
  *
  * \return #vs_snap_service_t SNAP service description. Use this pointer to call #vs_snap_register_service.
  */
-const vs_snap_service_t *
-vs_snap_info_client(vs_snap_info_callbacks_t callbacks);
+vs_snap_service_t *
+vs_snap_info_client(vs_snap_info_client_service_t impl);
 
 /** Enumerate devices
  *
@@ -225,10 +230,13 @@ vs_snap_info_enum_devices(const vs_netif_t *netif,
 /** Set pooling
  *
  * This call enables or disables polling for elements masked in \a elements field that contains mask  with
- * #vs_snap_info_element_mask_e fields. \param[in] netif #vs_netif_t SNAP service descriptor. If NULL, default one will
- * be used. \param[in] mac #vs_mac_addr_t MAC address. Must not be NULL. \param[in] elements
- * #vs_snap_info_element_mask_e mask. \param[out] enable Enable or disable \a elements to be sent. \param[in]
- * period_seconds Period in seconds for statistics sending
+ * #vs_snap_info_element_mask_e fields.
+ *
+ * \param[in] netif #vs_netif_t SNAP service descriptor. If NULL, default one will be used.
+ * \param[in] mac #vs_mac_addr_t MAC address. Must not be NULL.
+ * \param[in] elements #vs_snap_info_element_mask_e mask.
+ * \param[out] enable Enable or disable \a elements to be sent.
+ * \param[in] period_seconds Period in seconds for statistics sending
  *
  * \return #VS_CODE_OK in case of success or error code.
  */
@@ -240,7 +248,8 @@ vs_snap_info_set_polling(const vs_netif_t *netif,
                          uint16_t period_seconds);
 
 #ifdef __cplusplus
-}
+} // extern "C"
+} // namespace VirgilIoTKit
 #endif
 
 #endif // INFO_CLIENT

--- a/modules/protocols/snap/include/virgil/iot/protocols/snap/info/info-server.h
+++ b/modules/protocols/snap/include/virgil/iot/protocols/snap/info/info-server.h
@@ -50,7 +50,7 @@
  *
  *    vs_storage_op_ctx_t tl_storage_impl;        // Trust List storage implementation
  *    vs_storage_op_ctx_t fw_storage_impl;        // Firmware storage implementation
- *    const vs_snap_service_t *snap_info_server;  // INFO Server SNAP service
+ *    vs_snap_service_t *snap_info_server;        // INFO Server SNAP service
  *
  *     // Initialize tl_storage_impl, fw_storage_impl
  *
@@ -69,13 +69,14 @@
 
 #if INFO_SERVER
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 #include <virgil/iot/protocols/snap/snap-structs.h>
 #include <virgil/iot/firmware/firmware.h>
 #include "info-structs.h"
+
+#ifdef __cplusplus
+namespace VirgilIoTKit {
+extern "C" {
+#endif
 
 /** Startup notification
  *
@@ -99,7 +100,7 @@ typedef vs_status_e (*vs_snap_info_start_notif_srv_cb_t)(vs_snap_info_device_t *
  *
  * \return #vs_snap_service_t SNAP service description. Use this pointer to call #vs_snap_register_service.
  */
-const vs_snap_service_t *
+vs_snap_service_t *
 vs_snap_info_server(vs_storage_op_ctx_t *tl_ctx,
                     vs_storage_op_ctx_t *fw_ctx,
                     vs_snap_info_start_notif_srv_cb_t startup_cb);
@@ -116,7 +117,8 @@ vs_status_e
 vs_snap_info_start_notification(const vs_netif_t *netif);
 
 #ifdef __cplusplus
-}
+} // extern "C"
+} // namespace VirgilIoTKit
 #endif
 
 #endif // INFO_SERVER

--- a/modules/protocols/snap/include/virgil/iot/protocols/snap/info/info-structs.h
+++ b/modules/protocols/snap/include/virgil/iot/protocols/snap/info/info-structs.h
@@ -47,6 +47,11 @@
 #include <virgil/iot/trust_list/tl_structs.h>
 #include <virgil/iot/protocols/snap/snap-structs.h>
 
+#ifdef __cplusplus
+namespace VirgilIoTKit {
+extern "C" {
+#endif
+
 /** Device information
  *
  * Device information as parameter for #vs_snap_info_start_notif_cb_t function
@@ -101,5 +106,10 @@ typedef enum {
             HTONL_IN_COMPILE_TIME(0x0001), /**< General device information #vs_info_general_t will be sent */
     VS_SNAP_INFO_STATISTICS = HTONL_IN_COMPILE_TIME(0x0002), /**< Device statistic #vs_info_statistics_t will be sent */
 } vs_snap_info_element_mask_e;
+
+#ifdef __cplusplus
+} // extern "C"
+} // namespace VirgilIoTKit
+#endif
 
 #endif // VS_SECURITY_SDK_SNAP_SERVICES_INFO_STRUCTS_H

--- a/modules/protocols/snap/include/virgil/iot/protocols/snap/prvs/prvs-client.h
+++ b/modules/protocols/snap/include/virgil/iot/protocols/snap/prvs/prvs-client.h
@@ -43,9 +43,9 @@
  * Before first call it is necessary to register PRVS service :
  *
  * \code
- *    const vs_snap_service_t *snap_prvs_client;      // INFO service
- *    vs_snap_prvs_dnid_list_t dnid_list;             // Array of "Do Not Initialized Devices"
- *    uint32_t wait_ms = 3000;                        // Waiting 3 seconds for all devices enumerating
+ *    vs_snap_service_t *snap_prvs_client;      // INFO service
+ *    vs_snap_prvs_dnid_list_t dnid_list;       // Array of "Do Not Initialized Devices"
+ *    uint32_t wait_ms = 3000;                  // Waiting 3 seconds for all devices enumerating
  *
  *    // Initialize snap_prvs_client
  *
@@ -72,14 +72,16 @@
 
 #if PRVS_CLIENT
 
+#include <virgil/iot/protocols/snap/snap-structs.h>
+#include <virgil/iot/protocols/snap/prvs/prvs-structs.h>
+#include <virgil/iot/provision/provision-structs.h>
+
 #ifdef __cplusplus
+namespace VirgilIoTKit {
 extern "C" {
 #endif
 
-#include <virgil/iot/protocols/snap/snap-structs.h>
-
-#include <virgil/iot/protocols/snap/prvs/prvs-structs.h>
-#include <virgil/iot/provision/provision-structs.h>
+struct vs_snap_prvs_client_impl_t;
 
 /** Stop waiting implementation
  *
@@ -88,27 +90,33 @@ extern "C" {
  * \a stop_wait_func member or #vs_snap_prvs_client_impl_t structure.
  * \a wait_func member or #vs_snap_prvs_client_impl_t structure.
  *
+ * \param[in] ctx Service context.
  * \param[in] condition Condition buffer. Must not be NULL.
  * \param[in] expect Expected value to be set.
  *
  * \return #VS_CODE_OK in case of success or error code.
  */
-typedef vs_status_e (*vs_snap_prvs_stop_wait_t)(int *condition, int expect);
+typedef vs_status_e (*vs_snap_prvs_stop_wait_t)(struct vs_snap_prvs_client_impl_t *ctx, int *condition, int expect);
 
 /** Wait implementation
  *
  * This function checks \a condition variable during \a wait_ms when it will be equal to the \a idle condition
  *
+ * \param[in] ctx Service context.
  * \param[in] wait_ms Wait in milliseconds.
  * \param[in] condition Condition buffer. Must not be NULL.
  * \param[in] idle Idle condition.
  *
  * \return #VS_CODE_OK in case of success or error code.
  */
-typedef vs_status_e (*vs_snap_prvs_wait_t)(uint32_t wait_ms, int *condition, int idle);
+typedef vs_status_e (*vs_snap_prvs_wait_t)(struct vs_snap_prvs_client_impl_t *ctx,
+                                           uint32_t wait_ms,
+                                           int *condition,
+                                           int idle);
 
 /** PRVS client implementation */
-typedef struct {
+typedef struct vs_snap_prvs_client_impl_t {
+    void *user_data;                         /**< User data */
     vs_snap_prvs_stop_wait_t stop_wait_func; /**< Stop waiting implementation */
     vs_snap_prvs_wait_t wait_func;           /**< Wait implementation */
 } vs_snap_prvs_client_impl_t;
@@ -121,7 +129,7 @@ typedef struct {
  *
  * \return #vs_snap_service_t SNAP service description. Use this pointer to call #vs_snap_register_service.
  */
-const vs_snap_service_t *
+vs_snap_service_t *
 vs_snap_prvs_client(vs_snap_prvs_client_impl_t impl);
 
 /** Enumerate devices, which don't have initialization provision yet
@@ -289,7 +297,8 @@ vs_snap_prvs_set_tl_footer(const vs_netif_t *netif,
                            uint32_t wait_ms);
 
 #ifdef __cplusplus
-}
+} // extern "C"
+} // namespace VirgilIoTKit
 #endif
 
 #endif // PRVS_CLIENT

--- a/modules/protocols/snap/include/virgil/iot/protocols/snap/prvs/prvs-server.h
+++ b/modules/protocols/snap/include/virgil/iot/protocols/snap/prvs/prvs-server.h
@@ -47,7 +47,7 @@
  *
  *     vs_secmodule_impl_t *secmodule_impl;         // Security module implementation
  *     vs_storage_op_ctx_t slots_storage_impl;      // Slots storage implementation
- *     const vs_snap_service_t *snap_prvs_server;   // PRVS Server
+ *     vs_snap_service_t *snap_prvs_server;         // PRVS Server
 
  *     // Initialize slots_storage_impl, secmodule_impl.
  *
@@ -67,13 +67,15 @@
 
 #if PRVS_SERVER
 
-#ifdef __cplusplus
-extern "C" {
-#endif
 #include <virgil/iot/protocols/snap/snap-structs.h>
 #include <virgil/iot/protocols/snap/prvs/prvs-structs.h>
 #include <virgil/iot/provision/provision.h>
 #include <virgil/iot/secmodule/secmodule.h>
+
+#ifdef __cplusplus
+namespace VirgilIoTKit {
+extern "C" {
+#endif
 
 /** PRVS Server SNAP Service implementation
  *
@@ -83,11 +85,12 @@ extern "C" {
  *
  * \return #vs_snap_service_t SNAP service description. Use this pointer to call #vs_snap_register_service.
  */
-const vs_snap_service_t *
+vs_snap_service_t *
 vs_snap_prvs_server(vs_secmodule_impl_t *secmodule);
 
 #ifdef __cplusplus
-}
+} // extern "C"
+} // namespace VirgilIoTKit
 #endif
 
 #endif // PRVS_SERVER

--- a/modules/protocols/snap/include/virgil/iot/protocols/snap/prvs/prvs-structs.h
+++ b/modules/protocols/snap/include/virgil/iot/protocols/snap/prvs/prvs-structs.h
@@ -41,12 +41,13 @@
 #ifndef VS_SECURITY_SDK_SNAP_SERVICES_PRVS_STRUCTS_H
 #define VS_SECURITY_SDK_SNAP_SERVICES_PRVS_STRUCTS_H
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 #include <virgil/iot/protocols/snap/snap-structs.h>
 #include <virgil/iot/provision/provision-structs.h>
+
+#ifdef __cplusplus
+namespace VirgilIoTKit {
+extern "C" {
+#endif
 
 #define DNID_LIST_SZ_MAX (50)
 #define PUBKEY_MAX_SZ (100)
@@ -98,7 +99,8 @@ typedef struct __attribute__((__packed__)) {
 } vs_snap_prvs_sgnp_req_t;
 
 #ifdef __cplusplus
-}
+} // extern "C"
+} // namespace VirgilIoTKit
 #endif
 
 #endif // VS_SECURITY_SDK_SNAP_SERVICES_PRVS_STRUCTS_H

--- a/modules/protocols/snap/src/services/fldt/fldt-client.c
+++ b/modules/protocols/snap/src/services/fldt/fldt-client.c
@@ -697,9 +697,11 @@ vs_fldt_client_add_file_type(const vs_update_file_type_t *file_type, vs_update_i
 
 /******************************************************************/
 static vs_status_e
-_fldt_destroy_client(void) {
+_fldt_destroy_client(struct vs_snap_service_t *service) {
     uint32_t id;
     vs_fldt_client_file_type_mapping_t *file_type_mapping = _client_file_type_mapping;
+
+    (void)service;
 
     for (id = 0; id < _file_type_mapping_array_size; ++id, ++file_type_mapping) {
         file_type_mapping->update_interface->free_item(file_type_mapping->update_interface->storage_context,
@@ -714,14 +716,14 @@ _fldt_destroy_client(void) {
 
 /******************************************************************************/
 static int
-_fldt_client_request_processor(const struct vs_netif_t *netif,
+_fldt_client_request_processor(struct vs_snap_service_t *service,
                                vs_snap_element_t element_id,
                                const uint8_t *request,
                                const uint16_t request_sz,
                                uint8_t *response,
                                const uint16_t response_buf_sz,
                                uint16_t *response_sz) {
-    (void)netif;
+    (void)service;
 
     *response_sz = 0;
 
@@ -745,12 +747,12 @@ _fldt_client_request_processor(const struct vs_netif_t *netif,
 
 /******************************************************************************/
 static int
-_fldt_client_response_processor(const struct vs_netif_t *netif,
+_fldt_client_response_processor(struct vs_snap_service_t *service,
                                 vs_snap_element_t element_id,
                                 bool is_ack,
                                 const uint8_t *response,
                                 const uint16_t response_sz) {
-    (void)netif;
+    (void)service;
 
     switch (element_id) {
 
@@ -782,10 +784,12 @@ _fldt_client_response_processor(const struct vs_netif_t *netif,
 
 /******************************************************************************/
 static int
-_fldt_client_periodical_processor(void) {
+_fldt_client_periodical_processor(struct vs_snap_service_t *service) {
     vs_fldt_client_file_type_mapping_t *file_type_info = _client_file_type_mapping;
     vs_fldt_update_ctx_t *_update_ctx;
     uint32_t id;
+
+    (void)service;
 
     for (id = 0; id < _file_type_mapping_array_size; ++id, ++file_type_info) {
         _update_ctx = &file_type_info->update_ctx;
@@ -801,7 +805,7 @@ _fldt_client_periodical_processor(void) {
 }
 
 /******************************************************************************/
-const vs_snap_service_t *
+vs_snap_service_t *
 vs_snap_fldt_client(vs_fldt_got_file got_file_callback) {
 
     VS_IOT_ASSERT(got_file_callback);

--- a/modules/protocols/snap/src/services/info/info-server.c
+++ b/modules/protocols/snap/src/services/info/info-server.c
@@ -76,7 +76,9 @@ _fill_enum_data(vs_info_enum_response_t *enum_data) {
 
     // Set MAC address for default network interface
     default_netif = vs_snap_default_netif();
-    CHECK_RET(!default_netif->mac_addr(&enum_data->mac), -1, "Cannot get MAC for Default Network Interface");
+    CHECK_RET(!default_netif->mac_addr(default_netif, &enum_data->mac),
+              -1,
+              "Cannot get MAC for Default Network Interface");
 
     // Set current device roles
     enum_data->device_roles = vs_snap_device_roles();
@@ -143,15 +145,17 @@ terminate:
 /******************************************************************/
 static vs_status_e
 _fill_stat_data(vs_info_stat_response_t *stat_data) {
-    const vs_netif_t *defautl_netif;
+    const vs_netif_t *default_netif;
     vs_snap_stat_t stat = vs_snap_get_statistics();
 
     // Check input parameters
     CHECK_NOT_ZERO_RET(stat_data, VS_CODE_ERR_INCORRECT_ARGUMENT);
 
     // Set MAC address for default network interface
-    defautl_netif = vs_snap_default_netif();
-    CHECK_RET(!defautl_netif->mac_addr(&stat_data->mac), -1, "Cannot get MAC for Default Network Interface");
+    default_netif = vs_snap_default_netif();
+    CHECK_RET(!default_netif->mac_addr(default_netif, &stat_data->mac),
+              -1,
+              "Cannot get MAC for Default Network Interface");
 
     // Set statistics data
     stat_data->received = stat.received;
@@ -196,7 +200,7 @@ terminate:
 static vs_status_e
 _fill_ginf_data(vs_info_ginf_response_t *general_info) {
     vs_firmware_descriptor_t fw_descr;
-    const vs_netif_t *defautl_netif;
+    const vs_netif_t *default_netif;
     vs_tl_element_info_t tl_elem_info;
     vs_tl_header_t tl_header;
     uint16_t tl_header_sz = sizeof(tl_header);
@@ -205,9 +209,9 @@ _fill_ginf_data(vs_info_ginf_response_t *general_info) {
 
     CHECK_NOT_ZERO_RET(general_info, VS_CODE_ERR_INCORRECT_ARGUMENT);
 
-    defautl_netif = vs_snap_default_netif();
+    default_netif = vs_snap_default_netif();
 
-    CHECK_RET(!defautl_netif->mac_addr(&general_info->default_netif_mac),
+    CHECK_RET(!default_netif->mac_addr(default_netif, &general_info->default_netif_mac),
               -1,
               "Cannot get MAC for Default Network Interface");
 
@@ -313,14 +317,14 @@ _snot_request_processor(const uint8_t *request,
 
 /******************************************************************************/
 static vs_status_e
-_info_request_processor(const struct vs_netif_t *netif,
+_info_request_processor(struct vs_snap_service_t *service,
                         vs_snap_element_t element_id,
                         const uint8_t *request,
                         const uint16_t request_sz,
                         uint8_t *response,
                         const uint16_t response_buf_sz,
                         uint16_t *response_sz) {
-    (void)netif;
+    (void)service;
 
     *response_sz = 0;
 
@@ -350,10 +354,10 @@ _info_request_processor(const struct vs_netif_t *netif,
 
 /******************************************************************************/
 static vs_status_e
-_info_server_periodical_processor(void) {
+_info_server_periodical_processor(struct vs_snap_service_t *service) {
     vs_status_e ret_code;
-
     static bool started = false;
+    (void)service;
 
     // Send broadcast notification about self start
     if (!started) {
@@ -391,7 +395,7 @@ _info_server_periodical_processor(void) {
 }
 
 /******************************************************************************/
-const vs_snap_service_t *
+vs_snap_service_t *
 vs_snap_info_server(vs_storage_op_ctx_t *tl_ctx,
                     vs_storage_op_ctx_t *fw_ctx,
                     vs_snap_info_start_notif_srv_cb_t startup_cb) {

--- a/modules/protocols/snap/src/services/prvs/prvs-client.c
+++ b/modules/protocols/snap/src/services/prvs/prvs-client.c
@@ -61,7 +61,7 @@ static uint8_t _last_data[PRVS_BUF_SZ];
 
 /******************************************************************************/
 static vs_status_e
-_prvs_dnid_process_response(const struct vs_netif_t *netif, const uint8_t *response, const uint16_t response_sz) {
+_prvs_dnid_process_response(const uint8_t *response, const uint16_t response_sz) {
 
     vs_snap_prvs_dnid_element_t *dnid_response = (vs_snap_prvs_dnid_element_t *)response;
 
@@ -78,17 +78,18 @@ _prvs_dnid_process_response(const struct vs_netif_t *netif, const uint8_t *respo
 
 /******************************************************************************/
 static vs_status_e
-_prvs_service_response_processor(const struct vs_netif_t *netif,
+_prvs_service_response_processor(struct vs_snap_service_t *service,
                                  vs_snap_element_t element_id,
                                  bool is_ack,
                                  const uint8_t *response,
                                  const uint16_t response_sz) {
+    (void)service;
 
     VS_IOT_ASSERT(_prvs_impl.stop_wait_func);
 
     switch (element_id) {
     case VS_PRVS_DNID:
-        return _prvs_dnid_process_response(netif, response, response_sz);
+        return _prvs_dnid_process_response(response, response_sz);
 
     default: {
         if (response_sz && response_sz < PRVS_BUF_SZ) {
@@ -96,7 +97,7 @@ _prvs_service_response_processor(const struct vs_netif_t *netif,
             VS_IOT_MEMCPY(_last_data, response, response_sz);
         }
 
-        _prvs_impl.stop_wait_func(&_last_res, is_ack ? VS_CODE_OK : VS_CODE_ERR_PRVS_UNKNOWN);
+        _prvs_impl.stop_wait_func(&_prvs_impl, &_last_res, is_ack ? VS_CODE_OK : VS_CODE_ERR_PRVS_UNKNOWN);
 
         return VS_CODE_OK;
     }
@@ -104,7 +105,7 @@ _prvs_service_response_processor(const struct vs_netif_t *netif,
 }
 
 /******************************************************************************/
-const vs_snap_service_t *
+vs_snap_service_t *
 vs_snap_prvs_client(vs_snap_prvs_client_impl_t impl) {
     _prvs_client.user_data = 0;
     _prvs_client.id = VS_PRVS_SERVICE_ID;
@@ -178,7 +179,7 @@ vs_snap_prvs_set(const vs_netif_t *netif,
                      "Send request error");
 
     // Wait request
-    _prvs_impl.wait_func(wait_ms, &_last_res, VS_CODE_ERR_PRVS_UNKNOWN);
+    _prvs_impl.wait_func(&_prvs_impl, wait_ms, &_last_res, VS_CODE_ERR_PRVS_UNKNOWN);
 
     return _last_res;
 }
@@ -202,7 +203,7 @@ vs_snap_prvs_get(const vs_netif_t *netif,
     STATUS_CHECK_RET(vs_snap_send_request(netif, mac, VS_PRVS_SERVICE_ID, element, 0, 0), "Send request error");
 
     // Wait request
-    _prvs_impl.wait_func(wait_ms, &_last_res, VS_CODE_ERR_PRVS_UNKNOWN);
+    _prvs_impl.wait_func(&_prvs_impl, wait_ms, &_last_res, VS_CODE_ERR_PRVS_UNKNOWN);
 
     // Pass data
     if (VS_CODE_OK == _last_res && _last_data_sz <= buf_sz) {
@@ -248,7 +249,7 @@ vs_snap_prvs_sign_data(const vs_netif_t *netif,
                      "Send request error");
 
     // Wait request
-    _prvs_impl.wait_func(wait_ms, &_last_res, VS_CODE_ERR_PRVS_UNKNOWN);
+    _prvs_impl.wait_func(&_prvs_impl, wait_ms, &_last_res, VS_CODE_ERR_PRVS_UNKNOWN);
 
     // Pass data
     if (VS_CODE_OK == _last_res && _last_data_sz <= buf_sz) {

--- a/modules/protocols/snap/src/services/prvs/prvs-server.c
+++ b/modules/protocols/snap/src/services/prvs/prvs-server.c
@@ -241,8 +241,7 @@ vs_prvs_sign_data(const uint8_t *data, uint16_t data_sz, uint8_t *signature, uin
 
 /******************************************************************************/
 static vs_status_e
-_prvs_dnid_process_request(const struct vs_netif_t *netif,
-                           const uint8_t *request,
+_prvs_dnid_process_request(const uint8_t *request,
                            const uint16_t request_sz,
                            uint8_t *response,
                            const uint16_t response_buf_sz,
@@ -259,7 +258,7 @@ _prvs_dnid_process_request(const struct vs_netif_t *netif,
     }
 
     // Fill MAC address
-    vs_snap_mac_addr(netif, &dnid_response->mac_addr);
+    vs_snap_mac_addr(vs_snap_default_netif(), &dnid_response->mac_addr);
     dnid_response->device_roles = vs_snap_device_roles();
     *response_sz = sizeof(vs_snap_prvs_dnid_element_t);
 
@@ -268,17 +267,13 @@ _prvs_dnid_process_request(const struct vs_netif_t *netif,
 
 /******************************************************************************/
 static vs_status_e
-_prvs_key_save_process_request(const struct vs_netif_t *netif,
-                               vs_snap_element_t element_id,
-                               const uint8_t *key,
-                               const uint16_t key_sz) {
+_prvs_key_save_process_request(vs_snap_element_t element_id, const uint8_t *key, const uint16_t key_sz) {
     return vs_prvs_save_data(element_id, key, key_sz);
 }
 
 /******************************************************************************/
 static vs_status_e
-_prvs_devi_process_request(const struct vs_netif_t *netif,
-                           const uint8_t *request,
+_prvs_devi_process_request(const uint8_t *request,
                            const uint16_t request_sz,
                            uint8_t *response,
                            const uint16_t response_buf_sz,
@@ -299,8 +294,7 @@ _prvs_devi_process_request(const struct vs_netif_t *netif,
 
 /******************************************************************************/
 static vs_status_e
-_prvs_asav_process_request(const struct vs_netif_t *netif,
-                           const uint8_t *request,
+_prvs_asav_process_request(const uint8_t *request,
                            const uint16_t request_sz,
                            uint8_t *response,
                            const uint16_t response_buf_sz,
@@ -312,8 +306,7 @@ _prvs_asav_process_request(const struct vs_netif_t *netif,
 
 /******************************************************************************/
 static vs_status_e
-_prvs_asgn_process_request(const struct vs_netif_t *netif,
-                           const uint8_t *request,
+_prvs_asgn_process_request(const uint8_t *request,
                            const uint16_t request_sz,
                            uint8_t *response,
                            const uint16_t response_buf_sz,
@@ -332,7 +325,7 @@ _prvs_asgn_process_request(const struct vs_netif_t *netif,
 
 /******************************************************************************/
 static vs_status_e
-_prvs_start_tl_process_request(const struct vs_netif_t *netif, const uint8_t *request, const uint16_t request_sz) {
+_prvs_start_tl_process_request(const uint8_t *request, const uint16_t request_sz) {
     vs_status_e ret_code;
     STATUS_CHECK_RET(vs_prvs_start_save_tl(request, request_sz), "Unable to start save Trust List");
     return VS_CODE_OK;
@@ -340,7 +333,7 @@ _prvs_start_tl_process_request(const struct vs_netif_t *netif, const uint8_t *re
 
 /******************************************************************************/
 static vs_status_e
-_prvs_tl_part_process_request(const struct vs_netif_t *netif, const uint8_t *request, const uint16_t request_sz) {
+_prvs_tl_part_process_request(const uint8_t *request, const uint16_t request_sz) {
     vs_status_e ret_code;
     STATUS_CHECK_RET(vs_prvs_save_tl_part(request, request_sz), "Unable to save Trust List part");
     return VS_CODE_OK;
@@ -348,7 +341,7 @@ _prvs_tl_part_process_request(const struct vs_netif_t *netif, const uint8_t *req
 
 /******************************************************************************/
 static vs_status_e
-_prvs_finalize_tl_process_request(const struct vs_netif_t *netif, const uint8_t *request, const uint16_t request_sz) {
+_prvs_finalize_tl_process_request(const uint8_t *request, const uint16_t request_sz) {
     vs_status_e ret_code;
     STATUS_CHECK_RET(vs_prvs_finalize_tl(request, request_sz), "Unable to finalize Trust List");
     return VS_CODE_OK;
@@ -356,36 +349,38 @@ _prvs_finalize_tl_process_request(const struct vs_netif_t *netif, const uint8_t 
 
 /******************************************************************************/
 static vs_status_e
-_prvs_service_request_processor(const struct vs_netif_t *netif,
+_prvs_service_request_processor(struct vs_snap_service_t *service,
                                 vs_snap_element_t element_id,
                                 const uint8_t *request,
                                 const uint16_t request_sz,
                                 uint8_t *response,
                                 const uint16_t response_buf_sz,
                                 uint16_t *response_sz) {
+    (void)service;
+
     *response_sz = 0;
 
     switch (element_id) {
     case VS_PRVS_DNID:
-        return _prvs_dnid_process_request(netif, request, request_sz, response, response_buf_sz, response_sz);
+        return _prvs_dnid_process_request(request, request_sz, response, response_buf_sz, response_sz);
 
     case VS_PRVS_DEVI:
-        return _prvs_devi_process_request(netif, request, request_sz, response, response_buf_sz, response_sz);
+        return _prvs_devi_process_request(request, request_sz, response, response_buf_sz, response_sz);
 
     case VS_PRVS_ASAV:
-        return _prvs_asav_process_request(netif, request, request_sz, response, response_buf_sz, response_sz);
+        return _prvs_asav_process_request(request, request_sz, response, response_buf_sz, response_sz);
 
     case VS_PRVS_ASGN:
-        return _prvs_asgn_process_request(netif, request, request_sz, response, response_buf_sz, response_sz);
+        return _prvs_asgn_process_request(request, request_sz, response, response_buf_sz, response_sz);
 
     case VS_PRVS_TLH:
-        return _prvs_start_tl_process_request(netif, request, request_sz);
+        return _prvs_start_tl_process_request(request, request_sz);
 
     case VS_PRVS_TLC:
-        return _prvs_tl_part_process_request(netif, request, request_sz);
+        return _prvs_tl_part_process_request(request, request_sz);
 
     case VS_PRVS_TLF:
-        return _prvs_finalize_tl_process_request(netif, request, request_sz);
+        return _prvs_finalize_tl_process_request(request, request_sz);
 
     case VS_PRVS_PBR1:
     case VS_PRVS_PBR2:
@@ -396,7 +391,7 @@ _prvs_service_request_processor(const struct vs_netif_t *netif,
     case VS_PRVS_PBF1:
     case VS_PRVS_PBF2:
     case VS_PRVS_SGNP:
-        return _prvs_key_save_process_request(netif, element_id, request, request_sz);
+        return _prvs_key_save_process_request(element_id, request, request_sz);
 
     default:
         VS_LOG_ERROR("Unsupported PRVS request %d", element_id);
@@ -415,7 +410,7 @@ _prepare_prvs_service() {
 }
 
 /******************************************************************************/
-const vs_snap_service_t *
+vs_snap_service_t *
 vs_snap_prvs_server(vs_secmodule_impl_t *secmodule) {
 
     CHECK_NOT_ZERO_RET(secmodule, NULL);

--- a/modules/protocols/snap/src/snap.c
+++ b/modules/protocols/snap/src/snap.c
@@ -43,12 +43,12 @@
 #include <stdio.h>
 #include <string.h>
 
-static const vs_netif_t *_snap_default_netif = 0;
+static vs_netif_t *_snap_default_netif = 0;
 
 #define RESPONSE_SZ_MAX (1024)
 #define RESPONSE_RESERVED_SZ (sizeof(vs_snap_packet_t))
 #define SERVICES_CNT_MAX (10)
-static const vs_snap_service_t *_snap_services[SERVICES_CNT_MAX];
+static vs_snap_service_t *_snap_services[SERVICES_CNT_MAX];
 static uint32_t _snap_services_num = 0;
 static vs_mac_addr_t _snap_broadcast_mac = {.bytes = {0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF}};
 
@@ -86,7 +86,7 @@ _is_broadcast(const vs_mac_addr_t *mac_addr) {
 static bool
 _is_my_mac(const vs_netif_t *netif, const vs_mac_addr_t *mac_addr) {
     vs_mac_addr_t netif_mac_addr;
-    netif->mac_addr(&netif_mac_addr);
+    netif->mac_addr(netif, &netif_mac_addr);
 
     return 0 == memcmp(mac_addr->bytes, netif_mac_addr.bytes, ETH_ADDR_LEN);
 }
@@ -123,7 +123,7 @@ _process_packet(const vs_netif_t *netif, vs_snap_packet_t *packet) {
             // Process response
             if (packet->header.flags & VS_SNAP_FLAG_ACK || packet->header.flags & VS_SNAP_FLAG_NACK) {
                 if (_snap_services[i]->response_process) {
-                    _snap_services[i]->response_process(netif,
+                    _snap_services[i]->response_process(_snap_services[i],
                                                         packet->header.element_id,
                                                         !!(packet->header.flags & VS_SNAP_FLAG_ACK),
                                                         packet->content,
@@ -134,7 +134,7 @@ _process_packet(const vs_netif_t *netif, vs_snap_packet_t *packet) {
             } else if (_snap_services[i]->request_process) {
                 need_response = true;
                 _statistics.received++;
-                res = _snap_services[i]->request_process(netif,
+                res = _snap_services[i]->request_process(_snap_services[i],
                                                          packet->header.element_id,
                                                          packet->content,
                                                          packet->header.content_size,
@@ -180,7 +180,7 @@ _snap_periodical(void) {
     // Detect required command
     for (i = 0; i < _snap_services_num; i++) {
         if (_snap_services[i]->periodical_process) {
-            _snap_services[i]->periodical_process();
+            _snap_services[i]->periodical_process(_snap_services[i]);
         }
     }
 
@@ -341,9 +341,7 @@ vs_snap_init(vs_netif_t *default_netif,
     _snap_default_netif = default_netif;
 
     // Init default network interface
-    default_netif->init(_snap_rx_cb, _snap_process_cb);
-
-    return VS_CODE_OK;
+    return default_netif->init(default_netif, _snap_rx_cb, _snap_process_cb);
 }
 
 /******************************************************************************/
@@ -354,12 +352,12 @@ vs_snap_deinit() {
     CHECK_NOT_ZERO_RET(_snap_default_netif->deinit, VS_CODE_ERR_NULLPTR_ARGUMENT);
 
     // Stop network
-    _snap_default_netif->deinit();
+    _snap_default_netif->deinit(_snap_default_netif);
 
     // Deinit all services
     for (i = 0; i < _snap_services_num; i++) {
         if (_snap_services[i]->deinit) {
-            _snap_services[i]->deinit();
+            _snap_services[i]->deinit(_snap_services[i]);
         }
     }
 
@@ -393,7 +391,7 @@ vs_snap_send(const vs_netif_t *netif, const uint8_t *data, uint16_t data_sz) {
     }
 
     if (!netif || netif == _snap_default_netif) {
-        return _snap_default_netif->tx(data, data_sz);
+        return _snap_default_netif->tx(_snap_default_netif, data, data_sz);
     }
 
     return VS_CODE_ERR_SNAP_UNKNOWN;
@@ -401,7 +399,7 @@ vs_snap_send(const vs_netif_t *netif, const uint8_t *data, uint16_t data_sz) {
 
 /******************************************************************************/
 vs_status_e
-vs_snap_register_service(const vs_snap_service_t *service) {
+vs_snap_register_service(vs_snap_service_t *service) {
 
     VS_IOT_ASSERT(service);
 
@@ -424,7 +422,7 @@ vs_snap_mac_addr(const vs_netif_t *netif, vs_mac_addr_t *mac_addr) {
     if (!netif || netif == _snap_default_netif) {
         VS_IOT_ASSERT(_snap_default_netif);
         VS_IOT_ASSERT(_snap_default_netif->mac_addr);
-        _snap_default_netif->mac_addr(mac_addr);
+        _snap_default_netif->mac_addr(_snap_default_netif, mac_addr);
         return VS_CODE_OK;
     }
 

--- a/modules/provision/include/virgil/iot/provision/provision-structs.h
+++ b/modules/provision/include/virgil/iot/provision/provision-structs.h
@@ -78,6 +78,11 @@ init_manufacture_id(manufacture_id, MANUFACTURE_ID);
 #include <virgil/iot/status_code/status_code.h>
 #include <trust_list-config.h>
 
+#ifdef __cplusplus
+namespace VirgilIoTKit {
+extern "C" {
+#endif
+
 #if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
 #define HTONL_IN_COMPILE_TIME(val)                                                                                     \
     (uint32_t)(((uint32_t)val & 0xFF) << 24 | ((uint32_t)val & 0xFF00) << 8 | ((uint32_t)val & 0xFF0000) >> 8 |        \
@@ -233,5 +238,10 @@ typedef struct {
     vs_key_type_e key_type;
     uint8_t element_buf[VS_TL_STORAGE_MAX_PART_SIZE];
 } vs_provision_tl_find_ctx_t;
+
+#ifdef __cplusplus
+} // extern "C"
+} // namespace VirgilIoTKit
+#endif
 
 #endif // VS_IOT_PROVISION_STRUCTS_H

--- a/modules/provision/include/virgil/iot/provision/provision.h
+++ b/modules/provision/include/virgil/iot/provision/provision.h
@@ -102,6 +102,11 @@ if( vs_provision_tl_find_first_key(&search_ctx, VS_KEY_IOT_DEVICE, &pubkey_dated
 #include <virgil/iot/status_code/status_code.h>
 #include <virgil/iot/storage_hal/storage_hal.h>
 
+#ifdef __cplusplus
+namespace VirgilIoTKit {
+extern "C" {
+#endif
+
 /** Provision initialization
  *
  * This function must be called before any other Provision call.
@@ -218,5 +223,10 @@ vs_provision_tl_find_next_key(vs_provision_tl_find_ctx_t *search_ctx,
                               uint16_t *pubkey_sz,
                               uint8_t **meta,
                               uint16_t *meta_sz);
+
+#ifdef __cplusplus
+} // extern "C"
+} // namespace VirgilIoTKit
+#endif
 
 #endif // VS_IOT_PROVISION_H

--- a/modules/provision/trust_list/include/virgil/iot/trust_list/tl_structs.h
+++ b/modules/provision/trust_list/include/virgil/iot/trust_list/tl_structs.h
@@ -43,6 +43,11 @@
 #include <stdbool.h>
 #include <virgil/iot/provision/provision.h>
 
+#ifdef __cplusplus
+namespace VirgilIoTKit {
+extern "C" {
+#endif
+
 /** Trust List storage types */
 typedef enum {
     TL_STORAGE_TYPE_STATIC = 0, /**< Default Trust List backup for restoring it in case of provision error */
@@ -79,5 +84,10 @@ typedef struct vs_tl_element_info_s {
     vs_tl_element_e id;
     int index;
 } vs_tl_element_info_t;
+
+#ifdef __cplusplus
+} // extern "C"
+} // namespace VirgilIoTKit
+#endif
 
 #endif // TL_STRUCTS_H

--- a/modules/provision/trust_list/include/virgil/iot/trust_list/trust_list.h
+++ b/modules/provision/trust_list/include/virgil/iot/trust_list/trust_list.h
@@ -67,8 +67,8 @@
  *
  * // ...
  *
- *     const vs_snap_service_t *snap_fldt_server;      // FLDT Server service
- *     vs_mac_addr_t mac_addr;                         // Own MAC address
+ *     vs_snap_service_t *snap_fldt_server;      // FLDT Server service
+ *     vs_mac_addr_t mac_addr;                   // Own MAC address
  *
  *     // Initialize mac_addr
  *
@@ -119,6 +119,11 @@
 #include <virgil/iot/status_code/status_code.h>
 #include <virgil/iot/update/update.h>
 #include <virgil/iot/trust_list/tl_structs.h>
+
+#ifdef __cplusplus
+namespace VirgilIoTKit {
+extern "C" {
+#endif
 
 /** Trust List initialization
  *
@@ -209,5 +214,10 @@ vs_tl_header_to_host(const vs_tl_header_t *src_data, vs_tl_header_t *dst_data);
  */
 void
 vs_tl_header_to_net(const vs_tl_header_t *src_data, vs_tl_header_t *dst_data);
+
+#ifdef __cplusplus
+} // extern "C"
+} // namespace VirgilIoTKit
+#endif
 
 #endif // TRUST_LIST_H

--- a/modules/provision/trust_list/src/trust_list.c
+++ b/modules/provision/trust_list/src/trust_list.c
@@ -35,7 +35,7 @@
 #include <stdlib-config.h>
 
 #include "virgil/iot/trust_list/tl_structs.h"
-#include "private/tl-private.h"
+#include <private/tl-private.h>
 #include "virgil/iot/trust_list/trust_list.h"
 #include <endian-config.h>
 

--- a/modules/secbox/include/virgil/iot/secbox/secbox.h
+++ b/modules/secbox/include/virgil/iot/secbox/secbox.h
@@ -84,6 +84,11 @@
 #include <virgil/iot/status_code/status_code.h>
 #include <virgil/iot/secmodule/secmodule.h>
 
+#ifdef __cplusplus
+namespace VirgilIoTKit {
+extern "C" {
+#endif
+
 /** Security box operation type */
 typedef enum {
     VS_SECBOX_SIGNED,               /**< Signed data */
@@ -160,5 +165,10 @@ vs_secbox_load(vs_storage_element_id_t id, uint8_t *data, size_t data_sz);
  */
 vs_status_e
 vs_secbox_del(vs_storage_element_id_t id);
+
+#ifdef __cplusplus
+} // extern "C"
+} // namespace VirgilIoTKit
+#endif
 
 #endif // VS_IOT_SECBOX_H

--- a/tests/src/helpers/netif_test_impl.c
+++ b/tests/src/helpers/netif_test_impl.c
@@ -42,13 +42,13 @@ vs_mac_addr_t mac_addr_server_call;
 bool is_client_call;
 
 static vs_status_e
-test_netif_tx(const uint8_t *data, const uint16_t data_sz);
+test_netif_tx(struct vs_netif_t *netif, const uint8_t *data, const uint16_t data_sz);
 static vs_status_e
-test_netif_mac_addr(struct vs_mac_addr_t *mac_addr);
+test_netif_mac_addr(const struct vs_netif_t *netif, struct vs_mac_addr_t *mac_addr);
 static vs_status_e
-test_netif_init(const vs_netif_rx_cb_t rx_cb, const vs_netif_process_cb_t process_cb);
+test_netif_init(struct vs_netif_t *netif, const vs_netif_rx_cb_t rx_cb, const vs_netif_process_cb_t process_cb);
 static vs_status_e
-test_netif_deinit();
+test_netif_deinit(struct vs_netif_t *netif);
 
 static vs_netif_t _test_netif = {
         .init = test_netif_init,
@@ -63,10 +63,12 @@ static vs_netif_process_cb_t callback_process_cb;
 
 /**********************************************************/
 static vs_status_e
-test_netif_tx(const uint8_t *data, const uint16_t data_sz) {
+test_netif_tx(struct vs_netif_t *netif, const uint8_t *data, const uint16_t data_sz) {
     int ret_code = -1;
     const uint8_t *packet_data;
     uint16_t packet_data_sz;
+
+    (void)netif;
 
     is_client_call = !is_client_call;
 
@@ -81,8 +83,10 @@ test_netif_tx(const uint8_t *data, const uint16_t data_sz) {
 
 /**********************************************************/
 static vs_status_e
-test_netif_mac_addr(struct vs_mac_addr_t *mac_addr) {
+test_netif_mac_addr(const struct vs_netif_t *netif, struct vs_mac_addr_t *mac_addr) {
     VS_IOT_ASSERT(mac_addr);
+
+    (void)netif;
 
     *mac_addr = is_client_call ? mac_addr_client_call : mac_addr_server_call;
 
@@ -93,8 +97,10 @@ test_netif_mac_addr(struct vs_mac_addr_t *mac_addr) {
 
 /**********************************************************/
 static vs_status_e
-test_netif_init(const vs_netif_rx_cb_t rx_cb, const vs_netif_process_cb_t process_cb) {
+test_netif_init(struct vs_netif_t *netif, const vs_netif_rx_cb_t rx_cb, const vs_netif_process_cb_t process_cb) {
     VS_IOT_ASSERT(rx_cb);
+
+    (void)netif;
 
     callback_rx_cb = rx_cb;
     callback_process_cb = process_cb;
@@ -106,7 +112,10 @@ test_netif_init(const vs_netif_rx_cb_t rx_cb, const vs_netif_process_cb_t proces
 
 /**********************************************************/
 static vs_status_e
-test_netif_deinit() {
+test_netif_deinit(struct vs_netif_t *netif) {
+
+    (void)netif;
+
     netif_state.initialized = 0;
     netif_state.deinitialized = 1;
     return VS_CODE_OK;

--- a/tools/c-implementation/include/virgil/iot/tools/helpers/ti_wait_functionality.h
+++ b/tools/c-implementation/include/virgil/iot/tools/helpers/ti_wait_functionality.h
@@ -37,11 +37,12 @@
 
 #include <stdint.h>
 #include <virgil/iot/status_code/status_code.h>
+#include <virgil/iot/protocols/snap/prvs/prvs-client.h>
 
 vs_status_e
-vs_wait_func(uint32_t wait_ms, int *condition, int idle);
+vs_wait_func(struct vs_snap_prvs_client_impl_t *ctx, uint32_t wait_ms, int *condition, int idle);
 
 vs_status_e
-vs_wait_stop_func(int *condition, int expect);
+vs_wait_stop_func(struct vs_snap_prvs_client_impl_t *ctx, int *condition, int expect);
 
 #endif // VS_TOOLS_WAIT_FUNCTIONALITY_H

--- a/tools/c-implementation/src/hal/ti_netif_udp_bcast.c
+++ b/tools/c-implementation/src/hal/ti_netif_udp_bcast.c
@@ -46,16 +46,16 @@
 #include <virgil/iot/protocols/snap/snap-structs.h>
 
 static vs_status_e
-_udp_bcast_init(const vs_netif_rx_cb_t rx_cb, const vs_netif_process_cb_t process_cb);
+_udp_bcast_init(struct vs_netif_t *netif, const vs_netif_rx_cb_t rx_cb, const vs_netif_process_cb_t process_cb);
 
 static vs_status_e
-_udp_bcast_deinit();
+_udp_bcast_deinit(struct vs_netif_t *netif);
 
 static vs_status_e
-_udp_bcast_tx(const uint8_t *data, const uint16_t data_sz);
+_udp_bcast_tx(struct vs_netif_t *netif, const uint8_t *data, const uint16_t data_sz);
 
 static vs_status_e
-_udp_bcast_mac(struct vs_mac_addr_t *mac_addr);
+_udp_bcast_mac(const struct vs_netif_t *netif, struct vs_mac_addr_t *mac_addr);
 
 static vs_netif_t _netif_udp_bcast = {.user_data = NULL,
                                       .init = _udp_bcast_init,
@@ -173,15 +173,17 @@ _udp_bcast_connect() {
 
 terminate:
 
-    _udp_bcast_deinit();
+    _udp_bcast_deinit(&_netif_udp_bcast);
 
     return VS_CODE_ERR_SOCKET;
 }
 
 /******************************************************************************/
 static vs_status_e
-_udp_bcast_tx(const uint8_t *data, const uint16_t data_sz) {
+_udp_bcast_tx(struct vs_netif_t *netif, const uint8_t *data, const uint16_t data_sz) {
     struct sockaddr_in broadcast_addr;
+
+    (void)netif;
 
     memset((void *)&broadcast_addr, 0, sizeof(struct sockaddr_in));
     broadcast_addr.sin_family = AF_INET;
@@ -195,8 +197,9 @@ _udp_bcast_tx(const uint8_t *data, const uint16_t data_sz) {
 
 /******************************************************************************/
 static vs_status_e
-_udp_bcast_init(const vs_netif_rx_cb_t rx_cb, const vs_netif_process_cb_t process_cb) {
+_udp_bcast_init(struct vs_netif_t *netif, const vs_netif_rx_cb_t rx_cb, const vs_netif_process_cb_t process_cb) {
     assert(rx_cb);
+    (void)netif;
     _netif_udp_bcast_rx_cb = rx_cb;
     _netif_udp_bcast_process_cb = process_cb;
     _netif_udp_bcast.packet_buf_filled = 0;
@@ -207,7 +210,8 @@ _udp_bcast_init(const vs_netif_rx_cb_t rx_cb, const vs_netif_process_cb_t proces
 
 /******************************************************************************/
 static vs_status_e
-_udp_bcast_deinit() {
+_udp_bcast_deinit(struct vs_netif_t *netif) {
+    (void)netif;
     printf("Stop UDP broadcast\n");
     if (_udp_bcast_sock >= 0) {
 #if !defined(__APPLE__)
@@ -222,7 +226,8 @@ _udp_bcast_deinit() {
 
 /******************************************************************************/
 static vs_status_e
-_udp_bcast_mac(struct vs_mac_addr_t *mac_addr) {
+_udp_bcast_mac(const struct vs_netif_t *netif, struct vs_mac_addr_t *mac_addr) {
+    (void)netif;
 
     if (mac_addr) {
         memset(mac_addr->bytes, 0x01, sizeof(vs_mac_addr_t));

--- a/tools/c-implementation/src/helpers/ti_wait_functionality.c
+++ b/tools/c-implementation/src/helpers/ti_wait_functionality.c
@@ -47,7 +47,9 @@ static pthread_cond_t _wait_cond = PTHREAD_COND_INITIALIZER;
 
 /******************************************************************************/
 vs_status_e
-vs_wait_stop_func(int *condition, int expect) {
+vs_wait_stop_func(struct vs_snap_prvs_client_impl_t *ctx, int *condition, int expect) {
+    (void)ctx;
+
     if (0 != pthread_mutex_lock(&_wait_mutex)) {
         VS_LOG_ERROR("pthread_mutex_lock %s %d", strerror(errno), errno);
     }
@@ -77,9 +79,11 @@ _is_greater_timespec(struct timespec a, struct timespec b) {
 
 /******************************************************************************/
 vs_status_e
-vs_wait_func(uint32_t wait_ms, int *condition, int idle) {
+vs_wait_func(struct vs_snap_prvs_client_impl_t *ctx, uint32_t wait_ms, int *condition, int idle) {
     struct timespec time_to_wait;
     struct timespec ts_now;
+
+    (void)ctx;
 
     // Check for expected condition
     if (*condition != idle) {

--- a/tools/virgil-snapd/snap/snap.go
+++ b/tools/virgil-snapd/snap/snap.go
@@ -40,9 +40,9 @@ package snap
 #include <virgil/iot/protocols/snap/info/info-client.h>
 #include <virgil/iot/logger/logger.h>
 #include <virgil/iot/tools/hal/ti_netif_udp_bcast.h>
-extern int goDeviceStartNotifCb(vs_snap_info_device_t *device);
-extern int goGeneralInfoCb(vs_info_general_t *general_info);
-extern int goDeviceStatCb(vs_info_statistics_t *stat);
+extern int goDeviceStartNotifCb(struct vs_snap_service_t *service, vs_snap_info_device_t *device);
+extern int goGeneralInfoCb(struct vs_snap_service_t *service, vs_info_general_t *general_info);
+extern int goDeviceStatCb(struct vs_snap_service_t *service, vs_info_statistics_t *stat);
 
 static int go_snap_init(void) {
     vs_device_manufacture_id_t manufacture_id = {0};
@@ -62,13 +62,13 @@ static int _set_polling(void) {
 }
 
 static int _register_info_client(void) {
-    vs_snap_info_callbacks_t _cb;
+    vs_snap_info_client_service_t _impl;
 
-    _cb.device_start_cb = goDeviceStartNotifCb;
-    _cb.general_info_cb = goGeneralInfoCb;
-    _cb.statistics_cb = goDeviceStatCb;
+    _impl.device_start = goDeviceStartNotifCb;
+    _impl.general_info = goGeneralInfoCb;
+    _impl.statistics = goDeviceStatCb;
 
-    return vs_snap_register_service(vs_snap_info_client(_cb));
+    return vs_snap_register_service(vs_snap_info_client(_impl));
 }
 */
 import "C"
@@ -171,7 +171,7 @@ func roles2strings(roles C.uint32_t) []string {
 }
 
 //export goDeviceStartNotifCb
-func goDeviceStartNotifCb(device *C.vs_snap_info_device_t) C.int {
+func goDeviceStartNotifCb(service *C.vs_snap_service_t, device *C.vs_snap_info_device_t) C.int {
      if 0 != C._set_polling() {
         utils.Log.Println("can't set devices polling. SNAP:INFO:POLL error")
         return -1
@@ -181,7 +181,7 @@ func goDeviceStartNotifCb(device *C.vs_snap_info_device_t) C.int {
 }
 
 //export goGeneralInfoCb
-func goGeneralInfoCb(general_info *C.vs_info_general_t) C.int {
+func goGeneralInfoCb(service *C.vs_snap_service_t, general_info *C.vs_info_general_t) C.int {
     if nil != generalInfoCb {
         var goInfo devices.DeviceInfo
         goInfo.ID = ""
@@ -206,7 +206,7 @@ func goGeneralInfoCb(general_info *C.vs_info_general_t) C.int {
 }
 
 //export goDeviceStatCb
-func goDeviceStatCb(stat *C.vs_info_statistics_t) C.int {
+func goDeviceStatCb(service *C.vs_snap_service_t, stat *C.vs_info_statistics_t) C.int {
     if nil != statisticsCb {
         var goStat devices.DeviceInfo
         goStat.MAC = mac2string(&stat.default_netif_mac[0])


### PR DESCRIPTION
- Set VIRGIL_IOT_MCU_BUILD by default to OFF
- Enclose all headers to `namespace VirgilIoTKit { extern "C" { ... } }`
- Fix `_snap_fill_header` declaration
- Add context for C++ class compatibility, fix some return ones
- Rename `vs_snap_info_callbacks_t` to `vs_snap_info_client_service_t`
- Documentation fixes
- "Green" [IKIT-integration-test #665](https://jenkins-master-1609.virgilsecurity.com/view/IoT%20Kit/job/IKIT-integration-test/665/)
- "Yellow" because of PVS license [IKIT-tests #382](https://jenkins-master-1609.virgilsecurity.com/view/IoT%20Kit/job/IKIT-tests/382/)